### PR TITLE
add support for `Algebra Integral v1.2/v1.2.1`

### DIFF
--- a/packages/sushi/src/router/liquidity-providers/AlgebraIntegralV1Base.ts
+++ b/packages/sushi/src/router/liquidity-providers/AlgebraIntegralV1Base.ts
@@ -17,6 +17,6 @@ export const globalStateAbi = [
   },
 ] as const
 
-export abstract class AlgebraV2BaseProvider extends AlgebraV1BaseProvider {
+export abstract class AlgebraIntegralV1BaseProvider extends AlgebraV1BaseProvider {
   override gloablStateAbi = globalStateAbi as any
 }

--- a/packages/sushi/src/router/liquidity-providers/AlgebraIntegralV1_2Base.ts
+++ b/packages/sushi/src/router/liquidity-providers/AlgebraIntegralV1_2Base.ts
@@ -176,9 +176,22 @@ export abstract class AlgebraIntegralV1_2BaseProvider extends AlgebraIntegralV1B
               if (sqrtPriceX96 !== undefined) pool.sqrtPriceX96 = sqrtPriceX96
               if (liquidity !== undefined) pool.liquidity = liquidity
               // need to refecth balance if there custom fee on swap
-              if (overrideFee > 0n || pluginFee > 0n) {
-                this.onSwapPluginFeeUpdatePools.push(pool)
+              if (pluginFee > 0n || overrideFee > 0n) {
+                if (
+                  !this.onSwapPluginFeeUpdatePools.find(
+                    (v) =>
+                      v.address.toLowerCase() === pool.address.toLowerCase(),
+                  )
+                ) {
+                  this.onSwapPluginFeeUpdatePools.push(pool)
+                }
+                if (tick !== undefined) {
+                  pool.tick = tick
+                  pool.activeTick =
+                    Math.floor(tick / pool.tickSpacing) * pool.tickSpacing
+                }
               } else if (tick !== undefined) {
+                pool.tick = tick
                 pool.activeTick =
                   Math.floor(tick / pool.tickSpacing) * pool.tickSpacing
                 const newTicks = this.onPoolTickChange(pool.activeTick, pool)

--- a/packages/sushi/src/router/liquidity-providers/AlgebraIntegralV1_2Base.ts
+++ b/packages/sushi/src/router/liquidity-providers/AlgebraIntegralV1_2Base.ts
@@ -176,14 +176,18 @@ export abstract class AlgebraIntegralV1_2BaseProvider extends AlgebraIntegralV1B
               if (sqrtPriceX96 !== undefined) pool.sqrtPriceX96 = sqrtPriceX96
               if (liquidity !== undefined) pool.liquidity = liquidity
               // need to refecth balance if there custom fee on swap
+              const onSwapPoolExists = this.onSwapPluginFeeUpdatePools.find(
+                (v) => v.address.toLowerCase() === pool.address.toLowerCase(),
+              )
               if (pluginFee > 0n || overrideFee > 0n) {
-                if (
-                  !this.onSwapPluginFeeUpdatePools.find(
-                    (v) =>
-                      v.address.toLowerCase() === pool.address.toLowerCase(),
-                  )
-                ) {
+                if (!onSwapPoolExists) {
                   this.onSwapPluginFeeUpdatePools.push(pool)
+                  const index = this.newTicksQueue.findIndex(
+                    (v) => v[0].address === pool.address,
+                  )
+                  if (index > -1) {
+                    this.newTicksQueue.splice(index, 1)
+                  }
                 }
                 if (tick !== undefined) {
                   pool.tick = tick
@@ -191,19 +195,21 @@ export abstract class AlgebraIntegralV1_2BaseProvider extends AlgebraIntegralV1B
                     Math.floor(tick / pool.tickSpacing) * pool.tickSpacing
                 }
               } else if (tick !== undefined) {
-                pool.tick = tick
-                pool.activeTick =
-                  Math.floor(tick / pool.tickSpacing) * pool.tickSpacing
-                const newTicks = this.onPoolTickChange(pool.activeTick, pool)
-                const queue = this.newTicksQueue.find(
-                  (v) => v[0].address === pool.address,
-                )
-                if (queue) {
-                  for (const t of newTicks) {
-                    if (!queue[1].includes(t)) queue[1].push(t)
+                if (!onSwapPoolExists) {
+                  pool.tick = tick
+                  pool.activeTick =
+                    Math.floor(tick / pool.tickSpacing) * pool.tickSpacing
+                  const newTicks = this.onPoolTickChange(pool.activeTick, pool)
+                  const queue = this.newTicksQueue.find(
+                    (v) => v[0].address === pool.address,
+                  )
+                  if (queue) {
+                    for (const t of newTicks) {
+                      if (!queue[1].includes(t)) queue[1].push(t)
+                    }
+                  } else {
+                    this.newTicksQueue.push([pool, newTicks])
                   }
-                } else {
-                  this.newTicksQueue.push([pool, newTicks])
                 }
               }
             }

--- a/packages/sushi/src/router/liquidity-providers/AlgebraIntegralV1_2Base.ts
+++ b/packages/sushi/src/router/liquidity-providers/AlgebraIntegralV1_2Base.ts
@@ -1,0 +1,29 @@
+import { parseAbiItem } from 'viem'
+import { AlgebraIntegralV1BaseProvider } from './AlgebraIntegralV1Base.js'
+
+export const AlgebraIntegralV1_2EventsAbi = [
+  parseAbiItem(
+    'event Swap(address indexed sender, address indexed recipient, int256 amount0, int256 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick, uint24 overrideFee, uint24 pluginFee)',
+  ),
+  parseAbiItem(
+    'event Mint(address sender, address indexed owner, int24 indexed tickLower, int24 indexed tickUpper, uint128 amount, uint256 amount0, uint256 amount1)',
+  ),
+  parseAbiItem(
+    'event Collect(address indexed owner, address recipient, int24 indexed tickLower, int24 indexed tickUpper, uint128 amount0, uint128 amount1)',
+  ),
+  parseAbiItem(
+    'event Burn(address indexed owner, int24 indexed tickLower, int24 indexed tickUpper, uint128 amount, uint256 amount0, uint256 amount1, uint24 pluginFee)',
+  ),
+  parseAbiItem(
+    'event Flash(address indexed sender, address indexed recipient, uint256 amount0, uint256 amount1, uint256 paid0, uint256 paid1)',
+  ),
+  parseAbiItem('event Fee(uint16 fee)'),
+  parseAbiItem('event TickSpacing(int24 newTickSpacing)'),
+  parseAbiItem(
+    'event Pool(address indexed token0, address indexed token1, address pool)',
+  ),
+]
+
+export abstract class AlgebraIntegralV1_2BaseProvider extends AlgebraIntegralV1BaseProvider {
+  override eventsAbi = AlgebraIntegralV1_2EventsAbi as any
+}

--- a/packages/sushi/src/router/liquidity-providers/AlgebraIntegralV1_2Base.ts
+++ b/packages/sushi/src/router/liquidity-providers/AlgebraIntegralV1_2Base.ts
@@ -199,8 +199,8 @@ export abstract class AlgebraIntegralV1_2BaseProvider extends AlgebraIntegralV1B
                   (v) => v[0].address === pool.address,
                 )
                 if (queue) {
-                  for (const tick of newTicks) {
-                    if (!queue[1].includes(tick)) queue[1].push(tick)
+                  for (const t of newTicks) {
+                    if (!queue[1].includes(t)) queue[1].push(t)
                   }
                 } else {
                   this.newTicksQueue.push([pool, newTicks])

--- a/packages/sushi/src/router/liquidity-providers/AlgebraIntegralV1_2Base.ts
+++ b/packages/sushi/src/router/liquidity-providers/AlgebraIntegralV1_2Base.ts
@@ -1,4 +1,5 @@
-import { parseAbiItem } from 'viem'
+import { Log, parseAbiItem, parseEventLogs } from 'viem'
+import { RainV3Pool } from '../rain/UniswapV3Base.js'
 import { AlgebraIntegralV1BaseProvider } from './AlgebraIntegralV1Base.js'
 
 export const AlgebraIntegralV1_2EventsAbi = [
@@ -25,5 +26,181 @@ export const AlgebraIntegralV1_2EventsAbi = [
 ]
 
 export abstract class AlgebraIntegralV1_2BaseProvider extends AlgebraIntegralV1BaseProvider {
-  override eventsAbi = AlgebraIntegralV1_2EventsAbi as any
+  override eventsAbi = AlgebraIntegralV1_2EventsAbi
+  // used for pools that need reserve refetch upon swap with non zero plugin fee
+  onSwapPluginFeeUpdatePools: RainV3Pool[] = []
+
+  override async afterProcessLog(untilBlock: bigint) {
+    const reservesPromise = this.getReserves(this.onSwapPluginFeeUpdatePools, {
+      blockNumber: untilBlock,
+    })
+    const ticksPromise = this.getTicks(this.onSwapPluginFeeUpdatePools, {
+      blockNumber: untilBlock,
+    })
+    const newTicksQueue = [...this.newTicksQueue.splice(0)]
+    if (newTicksQueue.length) {
+      const newTicks = await this.getTicksInner(newTicksQueue, {
+        blockNumber: untilBlock,
+      })
+      if (newTicks) {
+        newTicksQueue.forEach(([pool], i) => {
+          newTicks?.[i]?.forEach((newTick, index) => {
+            pool.ticks.set(index, newTick)
+          })
+        })
+      } else {
+        // if unsuccessfull to get new ticks, put them back on queue for next try
+        this.newTicksQueue.push(...newTicksQueue)
+      }
+    }
+    const reserves = await reservesPromise
+    const ticks = await ticksPromise
+    for (let i = 0; i < this.onSwapPluginFeeUpdatePools.length; i++) {
+      const pool = this.onSwapPluginFeeUpdatePools[i]
+      const reserve = reserves[i]
+      const tick = ticks?.[i]
+      if (!pool) continue
+      if (typeof reserve !== 'undefined') {
+        pool.reserve0 = reserve[0]!
+        pool.reserve1 = reserve[1]!
+      }
+      if (typeof tick !== 'undefined') {
+        pool.ticks = tick
+      }
+    }
+    this.onSwapPluginFeeUpdatePools = []
+  }
+
+  /**
+   * Handles pool events and updates the pool cache with the results
+   */
+  override handlePoolEvents(log: Log) {
+    const logAddress = log.address.toLowerCase()
+    const pool = this.pools.get(logAddress)!
+    if (pool) {
+      try {
+        const event = parseEventLogs({ logs: [log], abi: this.eventsAbi })[0]!
+        switch (event.eventName) {
+          case 'Mint': {
+            const { amount, amount0, amount1 } = event.args
+            const { tickLower, tickUpper } = event.args
+            if (log.blockNumber! >= pool.blockNumber) {
+              pool.blockNumber = log.blockNumber!
+              if (
+                tickLower !== undefined &&
+                tickUpper !== undefined &&
+                amount !== undefined
+              ) {
+                const tick = pool.activeTick
+                if (tickLower <= tick && tick < tickUpper)
+                  pool.liquidity += amount
+              }
+              if (amount1 !== undefined && amount0 !== undefined) {
+                pool.reserve0 += amount0
+                pool.reserve1 += amount1
+              }
+              if (
+                tickLower !== undefined &&
+                tickUpper !== undefined &&
+                amount !== undefined
+              ) {
+                this.addTick(tickLower, amount, pool)
+                this.addTick(tickUpper, -amount, pool)
+              }
+            }
+            break
+          }
+          case 'Burn': {
+            const { amount } = event.args
+            const { tickLower, tickUpper } = event.args
+            if (log.blockNumber! >= pool.blockNumber) {
+              pool.blockNumber = log.blockNumber!
+              if (
+                tickLower !== undefined &&
+                tickUpper !== undefined &&
+                amount !== undefined
+              ) {
+                const tick = pool.activeTick
+                if (tickLower <= tick && tick < tickUpper)
+                  pool.liquidity -= amount
+              }
+              if (
+                tickLower !== undefined &&
+                tickUpper !== undefined &&
+                amount !== undefined
+              ) {
+                this.addTick(tickLower, -amount, pool)
+                this.addTick(tickUpper, amount, pool)
+              }
+            }
+            break
+          }
+          case 'Collect': {
+            if (log.blockNumber! >= pool.blockNumber) {
+              pool.blockNumber = log.blockNumber!
+              const { amount0, amount1 } = event.args
+              if (amount0 !== undefined && amount1 !== undefined) {
+                pool.reserve0 -= amount0
+                pool.reserve1 -= amount1
+              }
+            }
+            break
+          }
+          case 'Flash': {
+            if (log.blockNumber! >= pool.blockNumber) {
+              pool.blockNumber = log.blockNumber!
+              const { paid0, paid1 } = event.args
+              if (paid0 !== undefined && paid1 !== undefined) {
+                pool.reserve0 += paid0
+                pool.reserve1 += paid1
+              }
+            }
+            break
+          }
+          case 'Swap': {
+            if (log.blockNumber! >= pool.blockNumber) {
+              pool.blockNumber = log.blockNumber!
+              const {
+                amount0,
+                amount1,
+                sqrtPriceX96,
+                liquidity,
+                tick,
+                pluginFee,
+                overrideFee,
+              } = event.args
+              if (amount0 !== undefined && amount1 !== undefined) {
+                pool.reserve0 += amount0
+                pool.reserve1 += amount1
+              }
+              if (sqrtPriceX96 !== undefined) pool.sqrtPriceX96 = sqrtPriceX96
+              if (liquidity !== undefined) pool.liquidity = liquidity
+              // need to refecth balance if there custom fee on swap
+              if (overrideFee > 0n || pluginFee > 0n) {
+                this.onSwapPluginFeeUpdatePools.push(pool)
+              } else if (tick !== undefined) {
+                pool.activeTick =
+                  Math.floor(tick / pool.tickSpacing) * pool.tickSpacing
+                const newTicks = this.onPoolTickChange(pool.activeTick, pool)
+                const queue = this.newTicksQueue.find(
+                  (v) => v[0].address === pool.address,
+                )
+                if (queue) {
+                  for (const tick of newTicks) {
+                    if (!queue[1].includes(tick)) queue[1].push(tick)
+                  }
+                } else {
+                  this.newTicksQueue.push([pool, newTicks])
+                }
+              }
+            }
+            break
+          }
+          default: {
+            this.otherEventCases(log, event, pool)
+          }
+        }
+      } catch {}
+    }
+  }
 }

--- a/packages/sushi/src/router/liquidity-providers/AlgebraIntegralV1_2Base.ts
+++ b/packages/sushi/src/router/liquidity-providers/AlgebraIntegralV1_2Base.ts
@@ -76,7 +76,7 @@ export abstract class AlgebraIntegralV1_2BaseProvider extends AlgebraIntegralV1B
    */
   override handlePoolEvents(log: Log) {
     const logAddress = log.address.toLowerCase()
-    const pool = this.pools.get(logAddress)!
+    const pool = this.pools.get(logAddress)
     if (pool) {
       try {
         const event = parseEventLogs({ logs: [log], abi: this.eventsAbi })[0]!

--- a/packages/sushi/src/router/liquidity-providers/BladeSwap.ts
+++ b/packages/sushi/src/router/liquidity-providers/BladeSwap.ts
@@ -1,9 +1,9 @@
 import { PublicClient } from 'viem'
 import { ChainId } from '../../chain/index.js'
-import { AlgebraV2BaseProvider } from './AlgebraV2Base.js'
+import { AlgebraIntegralV1BaseProvider } from './AlgebraIntegralV1Base.js'
 import { LiquidityProviders } from './LiquidityProvider.js'
 
-export class BladeSwapProvider extends AlgebraV2BaseProvider {
+export class BladeSwapProvider extends AlgebraIntegralV1BaseProvider {
   constructor(chainId: ChainId, web3Client: PublicClient) {
     const factory = {
       [ChainId.BLAST]: '0xA87DbF5082Af26c9A6Ab2B854E378f704638CCa5',

--- a/packages/sushi/src/router/liquidity-providers/Fenix.ts
+++ b/packages/sushi/src/router/liquidity-providers/Fenix.ts
@@ -1,9 +1,9 @@
 import { PublicClient } from 'viem'
 import { ChainId } from '../../chain/index.js'
-import { AlgebraV2BaseProvider } from './AlgebraV2Base.js'
+import { AlgebraIntegralV1BaseProvider } from './AlgebraIntegralV1Base.js'
 import { LiquidityProviders } from './LiquidityProvider.js'
 
-export class FenixProvider extends AlgebraV2BaseProvider {
+export class FenixProvider extends AlgebraIntegralV1BaseProvider {
   constructor(chainId: ChainId, web3Client: PublicClient) {
     const factory = {
       [ChainId.BLAST]: '0x7a44CD060afC1B6F4c80A2B9b37f4473E74E25Df',

--- a/packages/sushi/src/router/liquidity-providers/GlyphV4.ts
+++ b/packages/sushi/src/router/liquidity-providers/GlyphV4.ts
@@ -1,9 +1,9 @@
 import { PublicClient } from 'viem'
 import { ChainId } from '../../chain/index.js'
-import { AlgebraV2BaseProvider } from './AlgebraV2Base.js'
+import { AlgebraIntegralV1BaseProvider } from './AlgebraIntegralV1Base.js'
 import { LiquidityProviders } from './LiquidityProvider.js'
 
-export class GlyphV4Provider extends AlgebraV2BaseProvider {
+export class GlyphV4Provider extends AlgebraIntegralV1BaseProvider {
   constructor(chainId: ChainId, web3Client: PublicClient) {
     const factory = {
       [ChainId.CORE]: '0x74EfE55beA4988e7D92D03EFd8ddB8BF8b7bD597',

--- a/packages/sushi/src/router/liquidity-providers/Horizon.ts
+++ b/packages/sushi/src/router/liquidity-providers/Horizon.ts
@@ -1,9 +1,9 @@
 import { PublicClient } from 'viem'
 import { ChainId } from '../../chain/index.js'
-import { AlgebraV2BaseProvider } from './AlgebraV2Base.js'
+import { AlgebraIntegralV1BaseProvider } from './AlgebraIntegralV1Base.js'
 import { LiquidityProviders } from './LiquidityProvider.js'
 
-export class HorizonProvider extends AlgebraV2BaseProvider {
+export class HorizonProvider extends AlgebraIntegralV1BaseProvider {
   constructor(chainId: ChainId, web3Client: PublicClient) {
     const factory = {
       [ChainId.LINEA]: '0xec4f2937e57a6F39087187816eCc83191E6dB1aB',

--- a/packages/sushi/src/router/liquidity-providers/Hydrex.ts
+++ b/packages/sushi/src/router/liquidity-providers/Hydrex.ts
@@ -1,9 +1,9 @@
 import { PublicClient } from 'viem'
 import { ChainId } from '../../chain/index.js'
-import { AlgebraV2BaseProvider } from './AlgebraV2Base.js'
+import { AlgebraIntegralV1_2BaseProvider } from './AlgebraIntegralV1_2Base.js'
 import { LiquidityProviders } from './LiquidityProvider.js'
 
-export class HydrexProvider extends AlgebraV2BaseProvider {
+export class HydrexProvider extends AlgebraIntegralV1_2BaseProvider {
   constructor(chainId: ChainId, web3Client: PublicClient) {
     const factory = {
       [ChainId.BASE]: '0x36077D39cdC65E1e3FB65810430E5b2c4D5fA29E',

--- a/packages/sushi/src/router/liquidity-providers/KimV4.ts
+++ b/packages/sushi/src/router/liquidity-providers/KimV4.ts
@@ -1,9 +1,9 @@
 import { PublicClient } from 'viem'
 import { ChainId } from '../../chain/index.js'
-import { AlgebraV2BaseProvider } from './AlgebraV2Base.js'
+import { AlgebraIntegralV1BaseProvider } from './AlgebraIntegralV1Base.js'
 import { LiquidityProviders } from './LiquidityProvider.js'
 
-export class KimV4Provider extends AlgebraV2BaseProvider {
+export class KimV4Provider extends AlgebraIntegralV1BaseProvider {
   constructor(chainId: ChainId, web3Client: PublicClient) {
     const factory = {
       [ChainId.BASE]: '0x2F0d41f94d5D1550b79A83D2fe85C82d68c5a3ca',

--- a/packages/sushi/src/router/liquidity-providers/Scribe.ts
+++ b/packages/sushi/src/router/liquidity-providers/Scribe.ts
@@ -1,9 +1,9 @@
 import { PublicClient } from 'viem'
 import { ChainId } from '../../chain/index.js'
-import { AlgebraV2BaseProvider } from './AlgebraV2Base.js'
+import { AlgebraIntegralV1BaseProvider } from './AlgebraIntegralV1Base.js'
 import { LiquidityProviders } from './LiquidityProvider.js'
 
-export class ScribeProvider extends AlgebraV2BaseProvider {
+export class ScribeProvider extends AlgebraIntegralV1BaseProvider {
   constructor(chainId: ChainId, web3Client: PublicClient) {
     const factory = {
       [ChainId.SCROLL]: '0xDc62aCDF75cc7EA4D93C69B2866d9642E79d5e2e',

--- a/packages/sushi/src/router/liquidity-providers/Swapsicle.ts
+++ b/packages/sushi/src/router/liquidity-providers/Swapsicle.ts
@@ -1,9 +1,9 @@
 import { PublicClient } from 'viem'
 import { ChainId } from '../../chain/index.js'
-import { AlgebraV2BaseProvider } from './AlgebraV2Base.js'
+import { AlgebraIntegralV1BaseProvider } from './AlgebraIntegralV1Base.js'
 import { LiquidityProviders } from './LiquidityProvider.js'
 
-export class SwapsicleProvider extends AlgebraV2BaseProvider {
+export class SwapsicleProvider extends AlgebraIntegralV1BaseProvider {
   constructor(chainId: ChainId, web3Client: PublicClient) {
     const factory = {
       [ChainId.TELOS]: '0xA09BAbf9A48003ae9b9333966a8Bda94d820D0d9',

--- a/packages/sushi/src/router/liquidity-providers/UniswapV3Base.ts
+++ b/packages/sushi/src/router/liquidity-providers/UniswapV3Base.ts
@@ -35,6 +35,7 @@ export interface V3Pool {
   fee: UniV3FeeType[keyof UniV3FeeType]
   sqrtPriceX96: bigint
   activeTick: number
+  tick: number
 }
 
 export const NUMBER_OF_SURROUNDING_TICKS = 1000 // 10% price impact
@@ -175,6 +176,7 @@ export abstract class UniswapV3BaseProvider extends LiquidityProvider {
         ...pool,
         sqrtPriceX96,
         activeTick,
+        tick,
       })
     })
 

--- a/packages/sushi/src/router/rain/AlgebraV1Base.ts
+++ b/packages/sushi/src/router/rain/AlgebraV1Base.ts
@@ -180,6 +180,7 @@ export abstract class AlgebraV1BaseProvider extends UniswapV3BaseProvider {
         reserve1: 0n,
         liquidity: 0n,
         blockNumber: options?.blockNumber ?? 0n,
+        tick,
       })
     })
 

--- a/packages/sushi/src/router/rain/RainDataFetcher.test.ts
+++ b/packages/sushi/src/router/rain/RainDataFetcher.test.ts
@@ -26,8 +26,9 @@ describe('RainDataFetcher tests', async () => {
   const protocols = {
     univ2: LiquidityProviders.UniswapV2, // Univ2
     univ3: LiquidityProviders.UniswapV3, // Univ3
-    algebra: LiquidityProviders.KimV4, // Algebra
+    algebraV1: LiquidityProviders.KimV4, // Algebra Integral v1/v1.1
     slipstream: LiquidityProviders.AerodromeSlipstream, // Slipstream
+    algebraV1_2: LiquidityProviders.Hydrex, // Algebra Integral V1.2/v1.2.1
   }
 
   // wait 60 sec before each test to avoid rpc ratelimiting
@@ -61,9 +62,9 @@ describe('RainDataFetcher tests', async () => {
     )
   })
 
-  it('should correctly update pools data by logs for Algebra protocol', async () => {
+  it('should correctly update pools data by logs for Algebra Integral v1/v1.1 protocol', async () => {
     await testRainDataFetcher(
-      [protocols.algebra],
+      [protocols.algebraV1],
       client,
       fromToken,
       toToken,
@@ -77,6 +78,19 @@ describe('RainDataFetcher tests', async () => {
   it('should correctly update pools data by logs for Slipstream protocol', async () => {
     await testRainDataFetcher(
       [protocols.slipstream],
+      client,
+      fromToken,
+      toToken,
+      amountIn,
+      gasPrice,
+      currentBlockNumber,
+      oldBlockNumber,
+    )
+  })
+
+  it('should correctly update pools data by logs for Algebra Integral v1.2/v1.2.1 protocol', async () => {
+    await testRainDataFetcher(
+      [protocols.algebraV1_2],
       client,
       fromToken,
       toToken,

--- a/packages/sushi/src/router/rain/RainDataFetcher.ts
+++ b/packages/sushi/src/router/rain/RainDataFetcher.ts
@@ -342,7 +342,7 @@ export class RainDataFetcher extends DataFetcher {
     const logsPromises = []
     const blockNumberSlices = []
     while (fromBlockSlice < untilBlock) {
-      let toBlock = untilBlock
+      let toBlock = untilBlock + 1n
       if (fromBlockSlice + 5n < untilBlock) {
         toBlock = fromBlockSlice + 5n
       }
@@ -352,7 +352,7 @@ export class RainDataFetcher extends DataFetcher {
           events: this.eventsAbi,
           address: addresses as `0x${string}`[],
           fromBlock: fromBlockSlice,
-          toBlock,
+          toBlock: toBlock - 1n,
         }),
       )
       fromBlockSlice += 5n

--- a/packages/sushi/src/router/rain/UniswapV3Base.ts
+++ b/packages/sushi/src/router/rain/UniswapV3Base.ts
@@ -146,6 +146,7 @@ export abstract class UniswapV3BaseProvider extends _UniswapV3BaseProvider {
         reserve1: 0n,
         liquidity: 0n,
         blockNumber: options?.blockNumber ?? 0n,
+        tick,
       })
     })
 
@@ -227,6 +228,8 @@ export abstract class UniswapV3BaseProvider extends _UniswapV3BaseProvider {
           pool.liquidity,
           pool.sqrtPriceX96,
           this.getMaxTickDiapason(pool.activeTick, pool),
+          undefined,
+          pool.tick,
         )
 
         return new UniV3PoolCode(

--- a/packages/sushi/src/router/rain/UniswapV3Base.ts
+++ b/packages/sushi/src/router/rain/UniswapV3Base.ts
@@ -642,6 +642,7 @@ export abstract class UniswapV3BaseProvider extends _UniswapV3BaseProvider {
               if (sqrtPriceX96 !== undefined) pool.sqrtPriceX96 = sqrtPriceX96
               if (liquidity !== undefined) pool.liquidity = liquidity
               if (tick !== undefined) {
+                pool.tick = tick
                 pool.activeTick =
                   Math.floor(tick / pool.tickSpacing) * pool.tickSpacing
                 const newTicks = this.onPoolTickChange(pool.activeTick, pool)

--- a/packages/sushi/src/router/rain/UniswapV3Base.ts
+++ b/packages/sushi/src/router/rain/UniswapV3Base.ts
@@ -650,8 +650,8 @@ export abstract class UniswapV3BaseProvider extends _UniswapV3BaseProvider {
                   (v) => v[0].address === pool.address,
                 )
                 if (queue) {
-                  for (const tick of newTicks) {
-                    if (!queue[1].includes(tick)) queue[1].push(tick)
+                  for (const t of newTicks) {
+                    if (!queue[1].includes(t)) queue[1].push(t)
                   }
                 } else {
                   this.newTicksQueue.push([pool, newTicks])

--- a/packages/sushi/src/router/rain/VelodromeSlipstreamBase.ts
+++ b/packages/sushi/src/router/rain/VelodromeSlipstreamBase.ts
@@ -425,6 +425,7 @@ export abstract class VelodromeSlipstreamBaseProvider extends UniswapV3BaseProvi
         liquidity: 0n,
         blockNumber: options?.blockNumber ?? 0n,
         feeType: pool.feeType,
+        tick,
       })
     })
 

--- a/packages/sushi/src/tines/RPool.ts
+++ b/packages/sushi/src/tines/RPool.ts
@@ -40,6 +40,8 @@ export abstract class RPool {
   // gasSpent: number = 0
   readonly minLiquidity: number
   readonly swapGasCost: number
+  tick?: number | undefined
+  activeTick?: number | undefined
 
   constructor(
     address: Address,
@@ -50,6 +52,8 @@ export abstract class RPool {
     reserve1: bigint,
     minLiquidity = TYPICAL_MINIMAL_LIQUIDITY,
     swapGasCost = TYPICAL_SWAP_GAS_COST,
+    tick?: number,
+    activeTick?: number | undefined,
   ) {
     this.address = address || '0x'
     this.token0 = token0
@@ -63,6 +67,8 @@ export abstract class RPool {
     this.swapGasCost = swapGasCost
     this.reserve0 = reserve0
     this.reserve1 = reserve1
+    this.tick = tick
+    this.activeTick = activeTick
   }
 
   updateReserves(res0: bigint, res1: bigint) {

--- a/packages/sushi/src/tines/UniV3Pool.ts
+++ b/packages/sushi/src/tines/UniV3Pool.ts
@@ -92,11 +92,12 @@ export class UniV3Pool extends RPool {
     fee: number,
     reserve0: bigint,
     reserve1: bigint,
-    tick: number,
+    activeTick: number,
     liquidity: bigint,
     sqrtPriceX96: bigint,
     ticks: CLTick[],
     nearestTick?: number,
+    tick?: number,
   ) {
     super(
       address,
@@ -109,6 +110,8 @@ export class UniV3Pool extends RPool {
       TYPICAL_SWAP_GAS_COST,
     )
     this.ticks = ticks
+    this.tick = tick
+    this.activeTick = activeTick
     if (address !== undefined) {
       if (this.ticks.length === 0) {
         this.ticks.push({ index: CL_MIN_TICK, DLiquidity: ZERO })
@@ -121,7 +124,7 @@ export class UniV3Pool extends RPool {
 
       this.liquidity = liquidity
       this.sqrtPriceX96 = sqrtPriceX96
-      this.nearestTick = nearestTick ?? this._findTickForPrice(tick)
+      this.nearestTick = nearestTick ?? this._findTickForPrice(activeTick)
     } else {
       // for deserialization
       this.liquidity = undefined as unknown as bigint


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
This PR adds support for `Algebra Integral v1.2 and v1.2.1` which are the same as `Algebra Integral v1 and v1.1` but differ in 2 of its events with 1 item.
Hydrex is v1.2/v1.2.1 which is fixed in the PR.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Algebra Integral v1 and v1.2 protocols across multiple liquidity providers.
  * Pool objects expose tick and activeTick for more accurate routing.

* **Improvements**
  * Smarter pool event processing with targeted tick/reserve refreshes after swaps (handles plugin-fee cases).
  * Adjusted log-fetching boundaries for more reliable incremental updates.

* **Tests**
  * Updated and added tests covering Algebra Integral v1 and v1.2 variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->