### PR TITLE
add cbBTC to Base routing bases

### DIFF
--- a/packages/sushi/src/config/bases-to-check-trades-against.ts
+++ b/packages/sushi/src/config/bases-to-check-trades-against.ts
@@ -441,6 +441,13 @@ export const BASES_TO_CHECK_TRADES_AGAINST: {
       symbol: 'cbETH',
       name: 'Coinbase Wrapped Staked ETH',
     }),
+    new Token({
+      chainId: ChainId.BASE,
+      address: '0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf',
+      decimals: 8,
+      symbol: 'cbBTC',
+      name: 'Coinbase Wrapped BTC',
+    }),
     USDC[ChainId.BASE],
     new Token({
       chainId: ChainId.BASE,

--- a/packages/sushi/src/router/rain/RainDataFetcher.ts
+++ b/packages/sushi/src/router/rain/RainDataFetcher.ts
@@ -334,7 +334,7 @@ export class RainDataFetcher extends DataFetcher {
       //   `pools block height: ${fromBlock}`,
       //   `requested block height: ${untilBlock}`,
       // ].join(', ')
-      return false;
+      return false
     }
     if (!poolAddresses.length) return false
     addresses.push(...poolAddresses)


### PR DESCRIPTION
## Summary

- Adds cbBTC (`0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf`, 8 decimals) to `BASES_TO_CHECK_TRADES_AGAINST` for Base chain

## Why

`getCurrencyCombinations()` uses this list to generate the token pairs checked when discovering pools. Without cbBTC in the list, the pair `wtMSTR/cbBTC` was never generated, so the Hydrex Algebra pool (`0x37077d100b369ab48c9e6b7b21c15eee4fdf9923`) was never queried — even though the Hydrex provider is fully registered.

This caused `inputToEthPrice: no-way` for wtMSTR orders in the Rain solver, blocking all trade modes from executing.

With cbBTC added, the router can now find the `wtMSTR/cbBTC` Hydrex pool and route `wtMSTR → cbBTC → WETH` to derive the ETH price.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Coinbase Wrapped BTC (cbBTC) as a base token on the Base chain, expanding tokens available for trade routing and liquidity paths.

* **Style**
  * Minor code formatting cleanup to improve consistency and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->